### PR TITLE
Fix backend selection

### DIFF
--- a/porthole/startup.py
+++ b/porthole/startup.py
@@ -126,8 +126,21 @@ def print_version():
     print("Porthole ", version)
     sys.exit(0)
 
+def usage():
+    """Display basic command line help"""
+    tabs = "\t\t"
+    print("Usage: porthole [OPTION...]\n")
+    print("  -h, --help" + tabs + "Show this help message")
+    print("  -l, --local" + tabs +
+          "Run a local version (use modules in current directory)")
+    print("  -v, --version" + tabs + "Output version information and exit")
+    print("  -d, --debug string" + tabs +
+          "Output debugging information to stderr")
+    print("  -b, --backend [portage, pkgcore]" + tabs + "Select backend")
+
 def set_backend(arg):
     if arg in Choices:
+        global BACKEND
         # fixme unused BACKEND
         BACKEND = Choices[arg]
         print("***** BACKEND set to:", BACKEND)
@@ -163,9 +176,6 @@ def main():
     #print "STARTUP: main(); loading preferences"
     config.Prefs = preferences.PortholePreferences(prefs_additions)
     #print config.Prefs
-    #print "STARTUP: main(); importing version"
-    # fixme unused version
-    from porthole.version import version
     #print "STARTUP: main(); importing utils"
     from porthole.utils import debug
     from porthole import backends
@@ -202,9 +212,6 @@ def main():
     Gtk.main()
     # save the prefs to disk for next time
     config.Prefs.save()
-    # fixme unused hits, misses
-    hits = backends.portage_lib.get_metadata.hits
-    misses = backends.portage_lib.get_metadata.misses
     print("metadata", backends.portage_lib.get_metadata.cache_info())
     sys.exit(0)
 

--- a/porthole/version.py
+++ b/porthole/version.py
@@ -31,15 +31,12 @@ ver_info = {}
 
 
 def get_git_info(prop):
-    global ver_info
     if ver_info == {}:
         commit = ''
         date = ''
         branch = ''
         try:
             from subprocess import Popen, PIPE
-            # fixme unused mp
-            mp= os.path.dirname(os.path.abspath(__file__))
             data = Popen([b"git",b"log", b"HEAD^..HEAD"],stdout=PIPE).communicate()[0].split(b'\n')
             branches = Popen([b"git",b"branch"],stdout=PIPE).communicate()[0].split(b'\n')
         except:


### PR DESCRIPTION
## Summary
- ensure `set_backend` properly modifies the global BACKEND value
- add missing `usage` function and clean up `startup` globals
- fix typos in `Dispatch_wait` to prevent runtime errors
- drop unused variables in `version`

## Testing
- `python3 -m compileall -q .`
- `pyflakes porthole/startup.py porthole/utils/dispatcher.py porthole/version.py`

------
https://chatgpt.com/codex/tasks/task_e_686826d8f678832faae24265a0472c8f